### PR TITLE
Fix omarchy-nvim pkgbuild lookup and include libs in tobi-try on ARM

### DIFF
--- a/install/arm_install_scripts/omarchy-nvim.sh
+++ b/install/arm_install_scripts/omarchy-nvim.sh
@@ -42,7 +42,22 @@ done
 
 # Build and install the package
 echo "Building and installing omarchy-nvim (this may take a while)..."
-cd omarchy-pkgs/pkgbuilds/omarchy-nvim
+repo_dir="/tmp/omarchy-pkgs"
+pkg_dir=""
+
+if [ -d "$repo_dir/pkgbuilds/omarchy-nvim" ]; then
+  pkg_dir="$repo_dir/pkgbuilds/omarchy-nvim"
+else
+  # Newer repo layout nests packages under pkgbuilds/edge
+  pkg_dir=$(find "$repo_dir/pkgbuilds" -maxdepth 2 -type d -name "omarchy-nvim" -print -quit 2>/dev/null)
+fi
+
+if [ -z "$pkg_dir" ] || [ ! -d "$pkg_dir" ]; then
+  echo "Could not find omarchy-nvim PKGBUILD under $repo_dir/pkgbuilds"
+  exit 1
+fi
+
+cd "$pkg_dir"
 makepkg -si --noconfirm
 
 cd ~

--- a/install/arm_install_scripts/tobi-try.sh
+++ b/install/arm_install_scripts/tobi-try.sh
@@ -1,22 +1,25 @@
 echo "Installing tobi-try for ARM..."
 
-# Check if try is already installed
-if command -v try &>/dev/null; then
+if command -v try &>/dev/null && [ -f /usr/local/lib/try/lib/tui.rb ]; then
   echo "tobi-try already installed, skipping"
   return 0
 fi
 
-# Download try.rb from GitHub
-echo "Downloading try.rb from GitHub..."
-curl -fsSL "https://raw.githubusercontent.com/tobi/try/main/try.rb" -o /tmp/try.rb
+tmp_dir="$(mktemp -d)"
+echo "Downloading tobi/try from GitHub..."
+curl -fsSL "https://github.com/tobi/try/archive/refs/heads/main.tar.gz" | tar -xz -C "$tmp_dir"
 
-# Fix shebang to use system Ruby (avoid mise conflicts)
-sed -i '1s|.*|#!/usr/bin/ruby|' /tmp/try.rb
+sudo mkdir -p /usr/local/lib/try
+sudo cp -a "$tmp_dir"/try-main/try.rb /usr/local/lib/try/
+sudo cp -a "$tmp_dir"/try-main/lib /usr/local/lib/try/
 
-# Install to /usr/bin
-sudo install -Dm755 /tmp/try.rb /usr/bin/try
+sudo tee /usr/local/bin/try >/dev/null <<'EOF'
+#!/usr/bin/env bash
+exec /usr/bin/env ruby /usr/local/lib/try/try.rb "$@"
+EOF
+sudo chmod 755 /usr/local/bin/try
+sudo ln -sf /usr/local/bin/try /usr/bin/try
 
-# Cleanup
-rm -f /tmp/try.rb
+rm -rf "$tmp_dir"
 
 echo "tobi-try installed successfully"


### PR DESCRIPTION
- Fix omarchy-nvim pkgbuild path lookup
- Include missing libs for ARM tobi-try install