### PR TITLE
Fix incorrect reboot and shutdown commands in System menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -580,8 +580,8 @@ show_system_menu() {
   *Hibernate*) systemctl hibernate ;;
   *Relaunch*) omarchy-cmd-relaunch ;;
   *Logout*) omarchy-system-logout ;;
-  *Restart*) omarchy-cmd-reboot ;;
-  *Shutdown*) omarchy-cmd-shutdown ;;
+  *Restart*) omarchy-system-reboot ;;
+  *Shutdown*) omarchy-system-shutdown ;;
   *) back_to show_main_menu ;;
   esac
 }


### PR DESCRIPTION
Fixes incorrect command names in the System menu:
- `omarchy-cmd-reboot` → `omarchy-system-reboot`
- `omarchy-cmd-shutdown` → `omarchy-system-shutdown`

The Restart and Shutdown options in the system menu were calling non-existent commands. This updates them to use the correct `omarchy-system-*` command names.