### PR TITLE
Fix battery detection on Apple Silicon / Asahi Linux

### DIFF
--- a/bin/omarchy-battery-capacity
+++ b/bin/omarchy-battery-capacity
@@ -3,7 +3,7 @@
 # Returns the battery full capacity in Wh (rounded to whole number).
 # Used by omarchy-battery-status for displaying battery capacity.
 
-battery_info=$(upower -i $(upower -e | grep BAT))
+battery_info=$(upower -i $(upower -e | grep '/battery_' | head -1))
 
 echo "$battery_info" | awk '/energy-full:/ {
     printf "%d", $2

--- a/bin/omarchy-battery-present
+++ b/bin/omarchy-battery-present
@@ -3,7 +3,7 @@
 # Returns true if a battery is present on the system.
 # Used by the battery monitor and other battery-related checks.
 
-for bat in /sys/class/power_supply/BAT*; do
+for bat in /sys/class/power_supply/*; do
   [[ -r $bat/present ]] &&
   [[ $(cat $bat/present) == "1" ]] &&
   [[ $(cat $bat/type) == "Battery" ]] &&

--- a/bin/omarchy-battery-remaining
+++ b/bin/omarchy-battery-remaining
@@ -3,7 +3,7 @@
 # Returns the battery percentage remaining as an integer.
 # Used by the battery monitor and the Ctrl + Shift + Super + B hotkey.
 
-upower -i $(upower -e | grep BAT) | awk '/percentage/ { 
+upower -i $(upower -e | grep '/battery_' | head -1) | awk '/percentage/ { 
     print int($2)
     exit
 }'

--- a/bin/omarchy-battery-remaining-time
+++ b/bin/omarchy-battery-remaining-time
@@ -2,7 +2,7 @@
 
 # Returns the battery time remaining (to empty or full) in a compact format.
 
-battery_info=$(upower -i $(upower -e | grep BAT))
+battery_info=$(upower -i $(upower -e | grep '/battery_' | head -1))
 
 echo "$battery_info" | awk '/time to (empty|full)/ {
     value = $4

--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -3,7 +3,7 @@
 # Returns a formatted battery status string with percentage and power draw/charge.
 # Used by the battery notification hotkey (Ctrl + Shift + Super + B).
 
-battery_info=$(upower -i $(upower -e | grep BAT))
+battery_info=$(upower -i $(upower -e | grep '/battery_' | head -1))
 
 percentage=$(echo "$battery_info" | awk '/percentage/ {
     print int($2)

--- a/migrations/1752168292.sh
+++ b/migrations/1752168292.sh
@@ -1,6 +1,6 @@
 echo "Enable battery low notifications for laptops"
 
-if ls /sys/class/power_supply/BAT* &>/dev/null && [[ ! -f ~/.local/share/omarchy/config/systemd/user/omarchy-battery-monitor.service ]]; then
+if omarchy-battery-present && [[ ! -f ~/.local/share/omarchy/config/systemd/user/omarchy-battery-monitor.service ]]; then
   mkdir -p ~/.config/systemd/user
 
   cp ~/.local/share/omarchy/config/systemd/user/omarchy-battery-monitor.* ~/.config/systemd/user/


### PR DESCRIPTION
On Apple Silicon, the battery shows up as macsmc-battery instead of BAT0.
All battery scripts assumed BAT* naming — which worked on x86 since upower
names the device battery_BAT0, but fails on Asahi where the kernel device is macsmc-battery.
The Ctrl+Alt+Super+B hotkey showed nothing and the low battery monitor never activated.

Fixed omarchy-battery-present to check all power supply entries — the existing type check
already filters out AC adapters. Fixed the four upower scripts to grep for /battery_ prefix
which upower uses for all batteries regardless of kernel device name. Fixed the migration
script to use omarchy-battery-present so the timer activates on fresh Asahi installs too.

<img width="1035" height="353" alt="alarm_battery" src="https://github.com/user-attachments/assets/f805a757-099b-4fa3-9e99-1a7b49fd3ff2" />